### PR TITLE
fix: 修复聊天列表多图查看错误

### DIFF
--- a/lib/src/pages/chat/chat_logic.dart
+++ b/lib/src/pages/chat/chat_logic.dart
@@ -591,11 +591,15 @@ class ChatLogic extends GetxController {
     }
     if (isSingleChat && visible && !message.isRead! && message.sendID != OpenIM.iMManager.uid) {
       print('mark as read：$index ${message.clientMsgID!} ${message.isRead}');
-      await OpenIM.iMManager.messageManager.markC2CMessageAsRead(
-        userID: uid!,
-        messageIDList: [message.clientMsgID!],
-      );
-      message.isRead = true;
+      try {
+        await OpenIM.iMManager.messageManager.markC2CMessageAsRead(
+          userID: uid!,
+          messageIDList: [message.clientMsgID!],
+        );
+        message.isRead = true;
+      }catch(e){
+        print('mark as read err :$index ${message.clientMsgID!} ${message.isRead} ${e.toString()}');
+      }
     }
   }
 

--- a/lib/src/utils/im_util.dart
+++ b/lib/src/utils/im_util.dart
@@ -127,9 +127,9 @@ class IMUtil {
   }) async {
     final picInfoList = <PicInfo>[];
     try {
-      var picElem;
-      var file;
       for (var msg in list) {
+        var picElem;
+        var file;
         picElem = msg.pictureElem;
         if (null != picElem.sourcePath && picElem.sourcePath.isNotEmpty) {
           file = File(picElem.sourcePath);


### PR DESCRIPTION
修复picElem.sourcePath为null时file还是上一次的值，导致点击查看大图时不是实际图片

log: 修复聊天列表多图查看错误